### PR TITLE
Use `Morph#getState` instead of `Morph.state`.

### DIFF
--- a/packages/ember-htmlbars/lib/hooks/component.js
+++ b/packages/ember-htmlbars/lib/hooks/component.js
@@ -4,7 +4,7 @@ import buildComponentTemplate, { buildHTMLTemplate } from 'ember-views/system/bu
 import lookupComponent from 'ember-htmlbars/utils/lookup-component';
 
 export default function componentHook(renderNode, env, scope, _tagName, params, attrs, templates, visitor) {
-  var state = renderNode.state;
+  var state = renderNode.getState();
 
   // Determine if this is an initial render or a re-render
   if (state.manager) {

--- a/packages/ember-htmlbars/lib/hooks/link-render-node.js
+++ b/packages/ember-htmlbars/lib/hooks/link-render-node.js
@@ -14,7 +14,7 @@ export default function linkRenderNode(renderNode, env, scope, path, params, has
 
   var keyword = env.hooks.keywords[path];
   if (keyword && keyword.link) {
-    keyword.link(renderNode.state, params, hash);
+    keyword.link(renderNode.getState(), params, hash);
   } else {
     switch (path) {
       case 'unbound': return true;

--- a/packages/ember-htmlbars/lib/keywords/collection.js
+++ b/packages/ember-htmlbars/lib/keywords/collection.js
@@ -147,15 +147,15 @@ export default {
     // of a mutable param and used it in its layout, because there are
     // no params at all.
     if (Object.keys(hash).length) {
-      return morph.state.manager.rerender(env, hash, visitor, true);
+      return morph.getState().manager.rerender(env, hash, visitor, true);
     }
   },
 
   render(node, env, scope, params, hash, template, inverse, visitor) {
-    var state = node.state;
+    var state = node.getState();
     var parentView = state.parentView;
 
-    var options = { component: node.state.viewClassOrInstance, layout: null };
+    var options = { component: state.viewClassOrInstance, layout: null };
     if (template) {
       options.createOptions = {
         _itemViewTemplate: template && { raw: template },

--- a/packages/ember-htmlbars/lib/keywords/component.js
+++ b/packages/ember-htmlbars/lib/keywords/component.js
@@ -59,14 +59,16 @@ export default {
   },
 
   render(morph, ...rest) {
-    if (morph.state.manager) {
-      morph.state.manager.destroy();
+    let state = morph.getState();
+
+    if (state.manager) {
+      state.manager.destroy();
     }
 
     // Force the component hook to treat this as a first-time render,
     // because normal components (`<foo-bar>`) cannot change at runtime,
     // but the `{{component}}` helper can.
-    morph.state.manager = null;
+    state.manager = null;
 
     render(morph, ...rest);
   },
@@ -75,7 +77,7 @@ export default {
 };
 
 function render(morph, env, scope, params, hash, template, inverse, visitor) {
-  let componentPath = morph.state.componentPath;
+  let componentPath = morph.getState().componentPath;
 
   // If the value passed to the {{component}} helper is undefined or null,
   // don't create a new ComponentNode.

--- a/packages/ember-htmlbars/lib/keywords/input.js
+++ b/packages/ember-htmlbars/lib/keywords/input.js
@@ -166,7 +166,7 @@ export default {
   },
 
   render(morph, env, scope, params, hash, template, inverse, visitor) {
-    env.hooks.component(morph, env, scope, morph.state.componentName, params, hash, { default: template, inverse }, visitor);
+    env.hooks.component(morph, env, scope, morph.getState().componentName, params, hash, { default: template, inverse }, visitor);
   },
 
   rerender(...args) {

--- a/packages/ember-htmlbars/lib/keywords/outlet.js
+++ b/packages/ember-htmlbars/lib/keywords/outlet.js
@@ -103,7 +103,7 @@ export default {
   },
 
   render(renderNode, env, scope, params, hash, template, inverse, visitor) {
-    var state = renderNode.state;
+    var state = renderNode.getState();
     var parentView = env.view;
     var outletState = state.outletState;
     var toRender = outletState.render;

--- a/packages/ember-htmlbars/lib/keywords/partial.js
+++ b/packages/ember-htmlbars/lib/keywords/partial.js
@@ -53,7 +53,7 @@ export default {
   },
 
   render(renderNode, env, scope, params, hash, template, inverse, visitor) {
-    var state = renderNode.state;
+    var state = renderNode.getState();
     if (!state.partialName) { return true; }
     var found = lookupPartial(env, state.partialName);
     if (!found) { return true; }

--- a/packages/ember-htmlbars/lib/keywords/view.js
+++ b/packages/ember-htmlbars/lib/keywords/view.js
@@ -212,7 +212,7 @@ export default {
     // of a mutable param and used it in its layout, because there are
     // no params at all.
     if (Object.keys(hash).length) {
-      return morph.state.manager.rerender(env, hash, visitor, true);
+      return morph.getState().manager.rerender(env, hash, visitor, true);
     }
   },
 
@@ -225,25 +225,25 @@ export default {
       hash.classNameBindings = hash.classNameBindings.split(' ');
     }
 
-    var state = node.state;
+    var state = node.getState();
     var parentView = state.parentView;
 
     var options = {
-      component: node.state.viewClassOrInstance,
+      component: state.viewClassOrInstance,
       layout: null
     };
 
     options.createOptions = {};
-    if (node.state.controller) {
+    if (state.controller) {
       // Use `_controller` to avoid stomping on a CP
       // that exists in the target view/component
-      options.createOptions._controller = node.state.controller;
+      options.createOptions._controller = state.controller;
     }
 
-    if (node.state.targetObject) {
+    if (state.targetObject) {
       // Use `_targetObject` to avoid stomping on a CP
       // that exists in the target view/component
-      options.createOptions._targetObject = node.state.targetObject;
+      options.createOptions._targetObject = state.targetObject;
     }
 
     if (state.manager) {

--- a/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
+++ b/packages/ember-htmlbars/lib/node-managers/component-node-manager.js
@@ -121,7 +121,7 @@ function processPositionalParams(renderNode, positionalParams, params, attrs) {
   // if the component is rendered via {{component}} helper, the first
   // element of `params` is the name of the component, so we need to
   // skip that when the positional parameters are constructed
-  const paramsStartIndex = renderNode.state.isComponentHelper ? 1 : 0;
+  const paramsStartIndex = renderNode.getState().isComponentHelper ? 1 : 0;
   const isNamed = typeof positionalParams === 'string';
   let paramsStream;
 

--- a/packages/ember-htmlbars/lib/utils/subscribe.js
+++ b/packages/ember-htmlbars/lib/utils/subscribe.js
@@ -17,7 +17,7 @@ export default function subscribe(node, env, scope, stream) {
       component._renderNode.isDirty = true;
     }
 
-    if (node.state.manager) {
+    if (node.getState().manager) {
       node.shouldReceiveAttrs = true;
     }
 

--- a/packages/ember-routing-htmlbars/lib/keywords/element-action.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/element-action.js
@@ -91,7 +91,7 @@ ActionHelper.registerAction = function({ actionId, node, eventName, preventDefau
         event.stopPropagation();
       }
 
-      let { target, actionName, actionArgs } = node.state;
+      let { target, actionName, actionArgs } = node.getState();
 
       run(function runRegisteredAction() {
         if (typeof actionName === 'function') {

--- a/packages/ember-routing-htmlbars/lib/keywords/render.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/render.js
@@ -117,7 +117,7 @@ export default {
   },
 
   render(node, env, scope, params, hash, template, inverse, visitor) {
-    var state = node.state;
+    var state = node.getState();
     var name = params[0];
     var context = params[1];
 
@@ -217,8 +217,6 @@ export default {
 
     hash.viewName = camelize(name);
 
-    // var state = node.state;
-    // var parentView = scope.view;
     if (template && template.raw) {
       template = template.raw;
     }
@@ -244,7 +242,7 @@ export default {
 
   rerender(node, env, scope, params, hash, template, inverse, visitor) {
     var model = read(params[1]);
-    node.state.controller.set('model', model);
+    node.getState().controller.set('model', model);
   }
 };
 

--- a/packages/ember-routing-htmlbars/tests/helpers/element_action_test.js
+++ b/packages/ember-routing-htmlbars/tests/helpers/element_action_test.js
@@ -88,7 +88,7 @@ QUnit.test('should by default target the view\'s controller', function() {
   var controller = {};
 
   ActionHelper.registerAction = function({ node }) {
-    registeredTarget = node.state.target;
+    registeredTarget = node.getState().target;
   };
 
   view = EmberView.create({
@@ -136,7 +136,7 @@ QUnit.test('should allow a target to be specified', function() {
   var registeredTarget;
 
   ActionHelper.registerAction = function({ node }) {
-    registeredTarget = node.state.target;
+    registeredTarget = node.getState().target;
   };
 
   var anotherTarget = EmberView.create();

--- a/packages/ember-views/lib/views/states/has_element.js
+++ b/packages/ember-views/lib/views/states/has_element.js
@@ -34,7 +34,7 @@ merge(hasElement, {
 
     renderNode.isDirty = true;
     internal.visitChildren(renderNode.childNodes, function(node) {
-      if (node.state && node.state.manager) {
+      if (node.getState().manager) {
         node.shouldReceiveAttrs = true;
       }
       node.isDirty = true;


### PR DESCRIPTION
This allows us to lazily create the state bucket for each morph, and
avoids creating a ton of extra objects that are unused.
